### PR TITLE
Keep commands list in memory rather than file on disk

### DIFF
--- a/sfdx-autocomplete.ps1
+++ b/sfdx-autocomplete.ps1
@@ -1,29 +1,44 @@
-<# file for storing sfdx commands for faster lookup#>
-$sfdxCommandsFilepath = "$ENV:temp/commands.sfdx"
+New-Variable -Name sfdxCommands -Scope Script -Force
 
-<# The below script is executed in the background when a new ps session starts to pull all sfdx commands into a file#>
+<# The below script is executed in the background when a new ps session starts to pull all sfdx commands into a variable #>
 $sfdxCommandsFileCreateBlock = {
-    param($filePath)
-    sfdx commands | Out-File "$filePath"
-    $sfdxCommands = @($(Get-Content -Path $filePath))
-    Remove-Item $filePath
-    return $sfdxCommands
+	return sfdx commands --json | ConvertFrom-Json
 }
 
-<# executes the above script in the background so user is not waiting for the shell to start#>
-$sfdxCommandsFileCreateJob = Start-Job -ScriptBlock $sfdxCommandsFileCreateBlock -ArgumentList "$sfdxCommandsFilepath"
+<# executes the above script in the background so user is not waiting for the shell to start #>
+$sfdxCommandsFileCreateJob = Start-Job -ScriptBlock $sfdxCommandsFileCreateBlock
 
-<# script block for autocomplete. looks up matching commands from the file created above#>
+<# script block for autocomplete. looks up matching commands from the file created above #>
 $scriptBlock = {
-    param($CommandName, $wordToComplete, $cursorPosition)
+    param($wordToComplete, $commandAst, $cursorPosition)
 
-    if (!$sfdxCommands)
+    if (!$script:sfdxCommands)
     {
-        $sfdxCommands = Receive-Job -Wait -Job $sfdxCommandsFileCreateJob
+        $script:sfdxCommands = Receive-Job -Wait -Job $sfdxCommandsFileCreateJob
         Remove-Job $sfdxCommandsFileCreateJob
     }
 
-    $sfdxCommands -match "$("$wordToComplete".replace('sfdx ','')).*"
+    if ($commandAst.CommandElements.Count -eq 1) <# List all commands #>
+    {
+        $script:sfdxCommands | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.id, $_.id, 'Method', $_.description)
+        }
+    }
+    elseif ($commandAst.CommandElements.Count -eq 2 -and $wordToComplete -ne "") <# Completing a command #>
+    {
+        $commandPattern = "^(force:)?" + $commandAst.CommandElements[1].Value + ".+" <# Complete if force: is not specified too #>
+        $script:sfdxCommands | Where-Object id -match $commandPattern | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.id, $_.id, 'Method', $_.description)
+        }
+    }
+    elseif ($commandAst.CommandElements.Count -gt 2) <# Completing a parameter #>
+    {
+        $parameterToMatch = $commandAst.CommandElements[-1].ToString().TrimStart("-") + "*";
+        
+        ($script:sfdxCommands | Where-Object id -eq $commandAst.CommandElements[1].Value).flags.PsObject.Properties | Where-Object Name -like $parameterToMatch | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new("--" + $_.Value.name, $_.Value.name, 'ParameterName', $_.Value.description)
+        }
+    }
 }
 <# register the above script to fire when tab is pressed following the sfdx command#>
 Register-ArgumentCompleter -Native -CommandName sfdx -ScriptBlock $scriptBlock

--- a/sfdx-autocomplete.ps1
+++ b/sfdx-autocomplete.ps1
@@ -1,20 +1,29 @@
 <# file for storing sfdx commands for faster lookup#>
-$sfdxCommandsFilepath = "$HOME/commands.sfdx"
+$sfdxCommandsFilepath = "$ENV:temp/commands.sfdx"
 
 <# The below script is executed in the background when a new ps session starts to pull all sfdx commands into a file#>
 $sfdxCommandsFileCreateBlock = {
     param($filePath)
     sfdx commands | Out-File "$filePath"
+    $sfdxCommands = @($(Get-Content -Path $filePath))
+    Remove-Item $filePath
+    return $sfdxCommands
 }
 
 <# executes the above script in the background so user is not waiting for the shell to start#>
-Start-Job -ScriptBlock $sfdxCommandsFileCreateBlock -ArgumentList "$sfdxCommandsFilepath" | Out-Null
+$sfdxCommandsFileCreateJob = Start-Job -ScriptBlock $sfdxCommandsFileCreateBlock -ArgumentList "$sfdxCommandsFilepath"
 
 <# script block for autocomplete. looks up matching commands from the file created above#>
 $scriptBlock = {
     param($CommandName, $wordToComplete, $cursorPosition)
 
-    @($(Get-Content -Path $sfdxCommandsFilepath)) -match "$("$wordToComplete".replace('sfdx ','')).*"
+    if (!$sfdxCommands)
+    {
+        $sfdxCommands = Receive-Job -Wait -Job $sfdxCommandsFileCreateJob
+        Remove-Job $sfdxCommandsFileCreateJob
+    }
+
+    $sfdxCommands -match "$("$wordToComplete".replace('sfdx ','')).*"
 }
 <# register the above script to fire when tab is pressed following the sfdx command#>
 Register-ArgumentCompleter -Native -CommandName sfdx -ScriptBlock $scriptBlock


### PR DESCRIPTION
I've made a small tweak to write the file to temp and then delete it after reading. The autocomplete now waits for it to be available too, if you are really quick with the first usage.